### PR TITLE
Strip newline and carriage returns out of $lib and $inc

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,9 @@ elsif ($^O eq 'MSWin32') {
   $lib = '-leay32'    if $Config{cc} =~ /gcc/;
 }
 
+$lib =~ s/[\r\n]+/ /g;
+$inc =~ s/[\r\n]+/ /g;
+
 WriteMakefile(
     'NAME'              => 'Crypt::OpenSSL::Bignum',
     'VERSION_FROM'      => 'Bignum.pm',


### PR DESCRIPTION
If the computed $lib and $inc string contain newlines or carriage
returns, the generated makefile is invalid.  Fix by replacing them with
spaces.

Fixes #5